### PR TITLE
chore: increase number of Cloud Run max instances

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
       '--add-cloudsql-instances', '${_CLOUDSQL_INSTANCE_CONNECTION_NAME}',
       '--set-env-vars', 'GOOGLE_CLOUD_PROJECT=$PROJECT_ID,SETTINGS_NAME=mle_django_settings,DJANGO_SETTINGS_MODULE=config.settings.production',
       '--min-instances', '1',
-      '--max-instances', '4',
+      '--max-instances', '8',
       '--memory', '512M',
       '--cpu', '1',
       '--set-secrets', '/tmp/secrets/.env=mle_django_settings:latest',


### PR DESCRIPTION
The max. has been increased from 4 to 8.

This addresses scenarios where load exceeds the capacity available
to serve it from Google Cloud Run.