### PR TITLE
fix: organisation integrity error during user registration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -326,6 +326,9 @@ ORGANISATION_NAME = env(
 ORGANISATION_EMAIL = env("ORGANISATION_EMAIL", default="info@savannahghi.org")
 ORGANISATION_PHONE = env("ORGANISATION_PHONE", default="+254790360360")
 
+# used by the user model to assign a default organisation to a user during creation
+DEFAULT_ORG_ID = env("DEFAULT_ORG_ID", default="4181df12-ca96-4f28-b78b-8e8ad88b25df")
+
 # BigAutoField needs migration of existing data and either changes to
 # dependencies or overriding dependencies
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/fahari/users/models.py
+++ b/fahari/users/models.py
@@ -8,17 +8,16 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from phonenumber_field.modelfields import PhoneNumberField
 
-DEFAULT_ORG_ID = "4181df12-ca96-4f28-b78b-8e8ad88b25df"
 DEFAULT_ORG_CODE = 1
 
 
 def default_organisation():
     try:
-        from fahari.common.models import Organisation  # intentional late imoort
+        from fahari.common.models import Organisation  # intentional late import
 
         org, _ = Organisation.objects.get_or_create(
             code=DEFAULT_ORG_CODE,
-            id=DEFAULT_ORG_ID,
+            id=settings.DEFAULT_ORG_ID,
             defaults={
                 "organisation_name": settings.ORGANISATION_NAME,
                 "email_address": settings.ORGANISATION_EMAIL,
@@ -28,7 +27,7 @@ def default_organisation():
         return org.pk
     except (ProgrammingError, Exception):  # pragma: nocover
         # this will occur during initial migrations on a clean db
-        return DEFAULT_ORG_ID
+        return settings.DEFAULT_ORG_ID
 
 
 class User(AbstractUser):


### PR DESCRIPTION
This PR fixes an organisation integrity error that occurs when creating a new user at registration. This occurs because the id of the default organisation is hardcoded but for some reason, the id of the current organisation in the database is different than the hardcoded one.

The solution is to move the id of the default organisation from source code to an environment variable. That way, the id can be changed to match that of the current organisation in the database.

