### PR TITLE
chore: add county column on system versions data tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           pytest
-#          coveralls   --service=github
+          coveralls   --service=github
 
-#      - name: Coveralls Finished
-#        uses: coverallsapp/github-action@master
-#        with:
-#          github-token: ${{ secrets.github_token }}
-#          parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/fahari/common/serializers/common_serializers.py
+++ b/fahari/common/serializers/common_serializers.py
@@ -23,7 +23,7 @@ class SystemSerializer(BaseSerializer):
 
 class UserFacilityAllotmentSerializer(BaseSerializer):
 
-    user_name = serializers.ReadOnlyField(source="user.username")
+    user_name = serializers.ReadOnlyField(source="user.__str__")
     allotment_type_name = serializers.ReadOnlyField(source="get_allotment_type_display")
 
     class Meta(BaseSerializer.Meta):

--- a/fahari/ops/serializers.py
+++ b/fahari/ops/serializers.py
@@ -25,6 +25,7 @@ class FacilitySystemSerializer(BaseSerializer):
 
     facility_name = serializers.ReadOnlyField()
     system_name = serializers.ReadOnlyField()
+    county = serializers.ReadOnlyField(source="facility.county")
     updated = serializers.DateTimeField(format="%d/%m/%Y", required=False)
 
     class Meta(BaseSerializer.Meta):

--- a/fahari/templates/pages/ops/versions.html
+++ b/fahari/templates/pages/ops/versions.html
@@ -37,6 +37,7 @@
                         <th>Facility</th>
                         <th>System</th>
                         <th>Version</th>
+                        <th>County</th>
                         <th>Last Updated</th>
                         <th></th>
                     </tr>
@@ -57,6 +58,7 @@ window.addEventListener("load", function(){
                 {data: "facility_name", name: "facility__name"},
                 {data: "system_name", name: "system__name"},
                 {data: "version", name: "version"},
+                {data: "county", name: "facility__county"},
                 {data: "updated", name: "updated"},
                 {
                     data: "url",


### PR DESCRIPTION
This PR adds a `county` column on the table in the system versions listing page. This allows for the system versions being displayed to be ordered by county.