### PR TITLE
chore: setup demo deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,14 +5,14 @@ steps:
       [
         "build",
         "-t",
-        "europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle:$COMMIT_SHA",
+        "europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle-${_DEPLOYMENT_TYPE}:$COMMIT_SHA",
         ".",
       ]
 
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
     args:
-      ["push", "europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle:$COMMIT_SHA"]
+      ["push", "europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle-${_DEPLOYMENT_TYPE}:$COMMIT_SHA"]
 
   # Deploy an image from Container Registry to Cloud Run
   - name: 'gcr.io/cloud-builders/gcloud'
@@ -20,23 +20,23 @@ steps:
       'beta',
       'run',
       'deploy',
-      'mle',
-      '--image', 'europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle:$COMMIT_SHA',
+      '${_SERVICE_NAME}',
+      '--image', 'europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle-${_DEPLOYMENT_TYPE}:$COMMIT_SHA',
       '--region', 'europe-west1',
       '--platform', 'managed',
       '--allow-unauthenticated',
       '--add-cloudsql-instances', '${_CLOUDSQL_INSTANCE_CONNECTION_NAME}',
-      '--set-env-vars', 'GOOGLE_CLOUD_PROJECT=$PROJECT_ID,SETTINGS_NAME=mle_django_settings,DJANGO_SETTINGS_MODULE=config.settings.production,DEFAULT_ORG_ID=99edd1b5-1ff2-49f4-8b0e-261c78909695',
+      '--set-env-vars', 'GOOGLE_CLOUD_PROJECT=$PROJECT_ID,SETTINGS_NAME=${_SETTINGS_NAME},DJANGO_SETTINGS_MODULE=config.settings.production,DEFAULT_ORG_ID=99edd1b5-1ff2-49f4-8b0e-261c78909695',
       '--min-instances', '1',
       '--max-instances', '8',
       '--memory', '512M',
       '--cpu', '1',
-      '--set-secrets', '/tmp/secrets/.env=mle_django_settings:latest',
+      '--set-secrets', '/tmp/secrets/.env=${_SETTINGS_NAME}:latest',
       '--timeout', '59m59s'
   ]
 
 images:
-  - "europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle:$COMMIT_SHA"
+  - "europe-west1-docker.pkg.dev/$PROJECT_ID/sghi/mle-${_DEPLOYMENT_TYPE}:$COMMIT_SHA"
 
 timeout: 1200s
 queueTtl: 3600s


### PR DESCRIPTION
This MR changes the `cloudbuild` config to be used for multiple deployments. For now, the supported deployments are production and demo but in the future, new deployments can be added easily without having to touch any source code.